### PR TITLE
remove log within createExperiment, fix scoping issue in getExperiment

### DIFF
--- a/lib/OptimizelyClient.js
+++ b/lib/OptimizelyClient.js
@@ -64,7 +64,7 @@ Promise.promisifyAll(rest, {
  * @description Optimizely Client Constructor
  * @param {object} authCredentials OAuth2 credentials with the following properties:
  * {
- *    @param {String} clientId 
+ *    @param {String} clientId
  *    @param {String} clientSecret
  *    @param {String} refreshToken
  *    @param {String} accessToken
@@ -73,15 +73,15 @@ Promise.promisifyAll(rest, {
  */
 var OptimizelyClient = function(authCredentials) {
     this.authCredentials = authCredentials;
-    
+
     this.baseUrl = "https://api.optimizely.com/v2/";
-    
+
     this.baseHeaders = {
         'Authorization': 'Bearer ' + this.authCredentials.accessToken,
         'Content-Type': 'application/json'
     };
   }
-  
+
   /**
  * Retrieves the access token by refresh token (if the access token has expired).
  */
@@ -90,7 +90,7 @@ OptimizelyClient.prototype.prepare = function() {
     if (this.authCredentials.refreshToken && this.isAccessTokenExpired()) {
         return this.getAccessTokenByRefreshToken();
     }
-    
+
     return Promise.resolve(this);
 };
 
@@ -101,19 +101,19 @@ OptimizelyClient.prototype.isAccessTokenExpired = function() {
     if (!this.authCredentials.accessToken) {
         return true;
     }
-    
+
     if (!this.authCredentials.expiresIn || !this.authCredentials.accessTokenTimestamp) {
         return true;
     }
-    
+
     var expiresIn = this.authCredentials.expiresIn;
     var accessTokenTimestamp = this.authCredentials.accessTokenTimestamp;
     var unixTimestamp = Math.round(+new Date()/1000);
-    
+
     if (accessTokenTimestamp + expiresIn < unixTimestamp) {
         return true;
     }
-    
+
     return false;
 }
 
@@ -121,46 +121,46 @@ OptimizelyClient.prototype.isAccessTokenExpired = function() {
  * Retrieves the access token by refresh token.
  */
 OptimizelyClient.prototype.getAccessTokenByRefreshToken = function() {
-    
+
     if (!this.authCredentials.clientId) {
         throw new Error('Client ID not set');
     }
-    
+
     if (!this.authCredentials.clientSecret) {
         throw new Error('Client secret not set');
     }
-    
+
     if (!this.authCredentials.refreshToken) {
         throw new Error('Refresh token not set');
     }
-    
-    var url = "https://app.optimizely.com/oauth2/token?refresh_token="+this.authCredentials.refreshToken+ 
+
+    var url = "https://app.optimizely.com/oauth2/token?refresh_token="+this.authCredentials.refreshToken+
                 "&client_id="+this.authCredentials.clientId+"&client_secret="+this.authCredentials.clientSecret+"&grant_type=refresh_token";
-                
+
     return rest.postAsync(url, {method: 'post', headers: this.baseHeaders}).then(function(data){
         this.authCredentials.accessToken = data.payload.access_token;
         this.authCredentials.tokenType = data.payload.token_type;
         this.authCredentials.expiresIn = data.payload.expires_in;
         this.authCredentials.accessTokenTimestamp = Math.round(+new Date()/1000);
-        
+
         this.baseHeaders = {
             'Authorization': 'Bearer ' + this.authCredentials.accessToken,
             'Content-Type': 'application/json'
         };
-        
+
         return this;
-    }.bind(this));            
+    }.bind(this));
 }
-  
+
 /**
  * Private function that retrieves meta information from HTTP headers.
  */
 function parseHttpHeaders(headers) {
     var meta = {};
-    
+
     for (var headerName in headers) {
         var headerValue = headers[headerName];
-        
+
         if (headerName=="x-ratelimit-limit") {
             meta.rateLimit = headerValue;
         } else if (headerName=="x-ratelimit-remaining") {
@@ -175,7 +175,7 @@ function parseHttpHeaders(headers) {
                 if (match) {
                     var url = match[1];
                     var rel = match[2];
-                    
+
                     var regexp2 = /[\?|&]page=(\d+)/;
                     var match2 = regexp2.exec(url);
                     if (match2) {
@@ -190,16 +190,16 @@ function parseHttpHeaders(headers) {
                     }
                 }
             } while (match);
-        } 
+        }
     }
-    
+
     return meta;
-}  
+}
 
   ////////////////
   //1. Projects
   ////////////////
-  
+
  /**
  * @public
  * @name  OptimizelyClient#getProjects
@@ -213,14 +213,14 @@ function parseHttpHeaders(headers) {
  */
 OptimizelyClient.prototype.getProjects = function(options) {
     var theUrl = this.baseUrl + 'projects?' + queryString.stringify(options);
-    
+
     return this.prepare().then(function(oc) {
         return rest.getAsync(theUrl, {headers:oc.baseHeaders}).then(function(data) {
             return {
                 url: theUrl,
-                statusCode:data.response.statusCode, 
-                rawHeaders: data.response.headers, 
-                meta: parseHttpHeaders(data.response.headers), 
+                statusCode:data.response.statusCode,
+                rawHeaders: data.response.headers,
+                meta: parseHttpHeaders(data.response.headers),
                 payload:data.payload
             };
         });
@@ -253,9 +253,9 @@ OptimizelyClient.prototype.getProject = function(options) {
         }).then(function(data){
             return {
                 url: theUrl,
-                statusCode:data.response.statusCode, 
-                rawHeaders: data.response.headers, 
-                meta: parseHttpHeaders(data.response.headers), 
+                statusCode:data.response.statusCode,
+                rawHeaders: data.response.headers,
+                meta: parseHttpHeaders(data.response.headers),
                 payload:data.payload
             };
         });
@@ -317,7 +317,7 @@ OptimizelyClient.prototype.updateProject = function(options) {
     });
   }
 
- 
+
 ////////////////
 //2. Experiments
 ////////////////
@@ -382,7 +382,7 @@ OptimizelyClient.prototype.getExperiment = function(options) {
     return this.prepare().then(function(oc){
         return rest.getAsync(theUrl, {
           method: 'get',
-          headers: this.baseHeaders
+          headers: oc.baseHeaders
         });
     }).then(function(data){
         return {
@@ -405,15 +405,14 @@ OptimizelyClient.prototype.getExperiment = function(options) {
  */
 OptimizelyClient.prototype.createExperiment = function(options, experiment) {
     var postUrl = this.baseUrl + 'experiments?' + queryString.stringify(options);
-    
+
     return this.prepare().then(function(oc) {
         return rest.postAsync(postUrl, {'headers':oc.baseHeaders, 'data': JSON.stringify(experiment)}).then(function(data) {
-            console.log("%o", data.payload);
             return {
                 url: postUrl,
-                statusCode:data.response.statusCode, 
-                rawHeaders: data.response.headers, 
-                meta: parseHttpHeaders(data.response.headers), 
+                statusCode:data.response.statusCode,
+                rawHeaders: data.response.headers,
+                meta: parseHttpHeaders(data.response.headers),
                 payload:data.payload
             };
         });
@@ -446,7 +445,7 @@ OptimizelyClient.prototype.updateExperiment = function(options, experiment) {
         };
     });
   }
-  
+
 /**
  *@pubilc
  *@name OptimizelyClient#deleteExperiment
@@ -480,7 +479,7 @@ OptimizelyClient.prototype.deleteExperiment = function(options) {
         };
     });
   }
-  
+
 /**
  * @public
  * @name  OptimizelyClient#getResults
@@ -492,7 +491,7 @@ OptimizelyClient.prototype.getExperimentResults = function(options) {
     var theUrl = this.baseUrl + 'experiments/' + options.id;
     delete options.id;
     theUrl += '/results?' + queryString.stringify(options);
-    
+
     return this.prepare().then(function(oc){
         return rest.getAsync(theUrl, {
             method: 'GET',
@@ -532,7 +531,7 @@ OptimizelyClient.prototype.getAudiences = function(options){
     options.id = options.id || "";
     if (!options.id) throw new Error("required: options.id");
     var theUrl = this.baseUrl + 'audiences?' + queryString.stringify(options);
-    return this.prepare().then(function(oc){ 
+    return this.prepare().then(function(oc){
         return rest.getAsync(theUrl, {
             method: 'get',
             headers: oc.baseHeaders
@@ -547,7 +546,7 @@ OptimizelyClient.prototype.getAudiences = function(options){
         };
     });
   }
-  
+
 /**
  * @pubilc
  * @name OptimizelyClient#getAudience
@@ -609,7 +608,7 @@ OptimizelyClient.prototype.createAudience = function(options) {
         };
     });
   }
-  
+
 /**
  * @public
  * @name  OptimizelyClient#updateAudience
@@ -641,7 +640,7 @@ OptimizelyClient.prototype.updateAudience = function(options) {
 ////////////////
 //4. Campaigns
 ////////////////
-  
+
 /**
  * @public
  * @name  OptimizelyClient#getCampaigns
@@ -655,7 +654,7 @@ OptimizelyClient.prototype.updateAudience = function(options) {
  */
 OptimizelyClient.prototype.getCampaigns = function(options){
     var theUrl = this.baseUrl + 'campaigns?' + queryString.stringify(options);
-    return this.prepare().then(function(oc){ 
+    return this.prepare().then(function(oc){
         return rest.getAsync(theUrl, {
             method: 'get',
             headers: oc.baseHeaders
@@ -670,7 +669,7 @@ OptimizelyClient.prototype.getCampaigns = function(options){
         };
     });
   }
-  
+
 /**
  * @pubilc
  * @name OptimizelyClient#getCampaign
@@ -712,7 +711,7 @@ OptimizelyClient.prototype.getCampaign = function(options) {
  * @returns {promise} A promise fulfilled with the created project
  */
 OptimizelyClient.prototype.createCampaign = function(options, campaign) {
-    
+
     var postUrl = this.baseUrl + 'campaigns?' + queryString.stringify(options);
     return this.prepare().then(function(oc){
         return rest.postAsync(postUrl, {
@@ -730,7 +729,7 @@ OptimizelyClient.prototype.createCampaign = function(options, campaign) {
         };
     });
   }
-  
+
 /**
  * @public
  * @name  OptimizelyClient#updateCampaign
@@ -761,7 +760,7 @@ OptimizelyClient.prototype.updateCampaign = function(options, campaign) {
         };
     });
   }
-  
+
   /**
  *@pubilc
  *@name OptimizelyClient#deleteCampaign
@@ -795,7 +794,7 @@ OptimizelyClient.prototype.deleteCampaign = function(options) {
         };
     });
   }
-  
+
 /**
  * @public
  * @name  OptimizelyClient#getCampaignResults
@@ -805,7 +804,7 @@ OptimizelyClient.prototype.deleteCampaign = function(options) {
 OptimizelyClient.prototype.getCampaignResults = function(options) {
     if (!options.id) throw new Error("required: options.id");
     var theUrl = this.baseUrl + 'campaigns/' + options.id + '/results?' + queryString.stringify(options);
-    
+
     return this.prepare().then(function(oc){
         return rest.getAsync(theUrl, {
             method: 'GET',
@@ -821,11 +820,11 @@ OptimizelyClient.prototype.getCampaignResults = function(options) {
         };
     });
   }
-  
+
 ////////////////
 // 5. Pages
 ////////////////
-  
+
 /**
  * @public
  * @name  OptimizelyClient#getPages
@@ -839,7 +838,7 @@ OptimizelyClient.prototype.getCampaignResults = function(options) {
  */
 OptimizelyClient.prototype.getPages = function(options){
     var theUrl = this.baseUrl + 'pages?' + queryString.stringify(options);
-    return this.prepare().then(function(oc){ 
+    return this.prepare().then(function(oc){
         return rest.getAsync(theUrl, {
             method: 'get',
             headers: oc.baseHeaders
@@ -854,7 +853,7 @@ OptimizelyClient.prototype.getPages = function(options){
         };
     });
   }
-  
+
 /**
  * @pubilc
  * @name OptimizelyClient#getPage
@@ -896,7 +895,7 @@ OptimizelyClient.prototype.getPage = function(options) {
  * @returns {promise} A promise fulfilled with the created Page
  */
 OptimizelyClient.prototype.createPage = function(options, page) {
-    
+
     var postUrl = this.baseUrl + 'pages?' + queryString.stringify(options);
     return this.prepare().then(function(oc){
         return rest.postAsync(postUrl, {
@@ -914,7 +913,7 @@ OptimizelyClient.prototype.createPage = function(options, page) {
         };
     });
   }
-  
+
 /**
  * @public
  * @name  OptimizelyClient#updatePage
@@ -942,7 +941,7 @@ OptimizelyClient.prototype.updatePage = function(options, page) {
         };
     });
   }
-  
+
   /**
  *@pubilc
  *@name OptimizelyClient#deletePage
@@ -976,11 +975,11 @@ OptimizelyClient.prototype.deletePage = function(options) {
         };
     });
   }
-  
+
 ////////////////
 // 6. Events
 ////////////////
-  
+
 /**
  * @public
  * @name  OptimizelyClient#getEvents
@@ -991,7 +990,7 @@ OptimizelyClient.prototype.deletePage = function(options) {
  */
 OptimizelyClient.prototype.getEvents = function(options){
     var theUrl = this.baseUrl + 'events?' + queryString.stringify(options);
-    return this.prepare().then(function(oc){ 
+    return this.prepare().then(function(oc){
         return rest.getAsync(theUrl, {
             method: 'get',
             headers: oc.baseHeaders
@@ -1006,7 +1005,7 @@ OptimizelyClient.prototype.getEvents = function(options){
         };
     });
   }
-  
+
 /**
  * @pubilc
  * @name OptimizelyClient#getEvent
@@ -1039,7 +1038,7 @@ OptimizelyClient.prototype.getEvent = function(options) {
         };
     });
   }
-  
+
 /**
  * @pubilc
  * @name OptimizelyClient#createInPageEvent
@@ -1049,7 +1048,7 @@ OptimizelyClient.prototype.getEvent = function(options) {
  * @returns {promise} A promise fulfilled with the created In-Page Event
  */
 OptimizelyClient.prototype.createInPageEvent = function(options, page) {
-    
+
     var postUrl = this.baseUrl + 'pages/' + options.page_id + '/events';
     return this.prepare().then(function(oc){
         return rest.postAsync(postUrl, {
@@ -1077,7 +1076,7 @@ OptimizelyClient.prototype.createInPageEvent = function(options, page) {
  * @returns {promise} A promise fulfilled with the created In-Page Event
  */
 OptimizelyClient.prototype.createCustomEvent = function(options, page) {
-    
+
     var postUrl = this.baseUrl + 'projects/' + options.project_id + '/custom_events';
     return this.prepare().then(function(oc){
         return rest.postAsync(postUrl, {
@@ -1095,7 +1094,7 @@ OptimizelyClient.prototype.createCustomEvent = function(options, page) {
         };
     });
   }
-  
+
 /**
  * @public
  * @name  OptimizelyClient#updateInPageEvent
@@ -1152,7 +1151,7 @@ OptimizelyClient.prototype.updateCustomEvent = function(options, event) {
     });
   }
 
-  
+
  /**
  *@pubilc
  *@name OptimizelyClient#deleteInPageEvent
@@ -1210,11 +1209,11 @@ OptimizelyClient.prototype.deleteCustomEvent = function(options) {
         };
     });
   }
-  
+
 ////////////////
 //7. Attributes
 ////////////////
-  
+
 /**
  * @public
  * @name  OptimizelyClient#getAttributes
@@ -1228,7 +1227,7 @@ OptimizelyClient.prototype.deleteCustomEvent = function(options) {
  */
 OptimizelyClient.prototype.getAttributes = function(options){
     var theUrl = this.baseUrl + 'attributes?' + queryString.stringify(options);
-    return this.prepare().then(function(oc){ 
+    return this.prepare().then(function(oc){
         return rest.getAsync(theUrl, {
             method: 'get',
             headers: oc.baseHeaders
@@ -1243,7 +1242,7 @@ OptimizelyClient.prototype.getAttributes = function(options){
         };
     });
   }
-  
+
 /**
  * @pubilc
  * @name OptimizelyClient#getAttribute
@@ -1284,7 +1283,7 @@ OptimizelyClient.prototype.getAttribute = function(options) {
  * @returns {promise} A promise fulfilled with the created attribute
  */
 OptimizelyClient.prototype.createAttribute = function(attribute) {
-    
+
     var postUrl = this.baseUrl + 'attributes';
     return this.prepare().then(function(oc){
         return rest.postAsync(postUrl, {
@@ -1302,7 +1301,7 @@ OptimizelyClient.prototype.createAttribute = function(attribute) {
         };
     });
   }
-  
+
 /**
  * @public
  * @name  OptimizelyClient#updateAttribute
@@ -1331,7 +1330,7 @@ OptimizelyClient.prototype.updateAttribute = function(options, attribute) {
         };
     });
   }
-  
+
   /**
  *@pubilc
  *@name OptimizelyClient#deleteAttribute
@@ -1365,5 +1364,5 @@ OptimizelyClient.prototype.deleteAttribute = function(options) {
         };
     });
   }
-  
+
 module.exports = OptimizelyClient;


### PR DESCRIPTION
Hello, please accept this tiny pull request to fix a scoping issue for "getExperiments" where this is no longer pointing to the correct object and the removal of a console log on successful experiment creation.

```
- headers: this.baseHeaders
+ headers: oc.baseHeaders
```
was getting "error: unable to pull project: Missing authorization header"
```
console.log("%o", data.payload);
```
was causing issues on createExperiment

Thanks